### PR TITLE
bug

### DIFF
--- a/src/taobao/Application.php
+++ b/src/taobao/Application.php
@@ -73,7 +73,7 @@ class Application
 			$postMultipart = false;
 			foreach ($postFields as $k => $v)
 			{
-				if(!is_string($v))
+				if(!is_string($v) && !is_numeric($v))
 					continue ;
 				if("@" != substr($v, 0, 1))//判断是不是文件上传
 				{


### PR DESCRIPTION
if(!is_string($v) && !is_numeric($v)) ,或者修改不为空
像官方文档page_no，page_size ，参数都是number类型，is_string 会过滤number等类型的参数，导致该字段传输丢失.